### PR TITLE
refactor: update getty configuration for new api

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -115,6 +115,11 @@ const (
 
 	// graceful shutdown
 	DefaultGracefulShutdownTimeout = 10 * time.Second
+
+	// MaxWheelTimeSpan consumer side max wait time for heartbeat-period
+	MaxWheelTimeSpan = 900e9 // 900s, 15 minute
+	// DefaultHeartbeatTimeout consumer default heartbeat timeout
+	DefaultHeartbeatTimeout = 60 * time.Second
 )
 
 const (

--- a/compat.go
+++ b/compat.go
@@ -979,3 +979,15 @@ func compatGlobalProfilesConfig(c *config.ProfilesConfig) *global.ProfilesConfig
 		Active: c.Active,
 	}
 }
+
+func CompatGlobalTLSConfig(c *config.TLSConfig) *global.TLSConfig {
+	if c == nil {
+		return nil
+	}
+	return &global.TLSConfig{
+		CACertFile:    c.CACertFile,
+		TLSCertFile:   c.TLSCertFile,
+		TLSKeyFile:    c.TLSKeyFile,
+		TLSServerName: c.TLSServerName,
+	}
+}

--- a/config/consumer_config.go
+++ b/config/consumer_config.go
@@ -36,10 +36,6 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
-const (
-	MaxWheelTimeSpan = 900e9 // 900s, 15 minute
-)
-
 // ConsumerConfig is Consumer default configuration
 type ConsumerConfig struct {
 	Filter                         string                      `yaml:"filter" json:"filter,omitempty" property:"filter"`

--- a/remoting/getty/config.go
+++ b/remoting/getty/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
 const (
@@ -212,13 +212,13 @@ func (c *ClientConfig) CheckValidity() error {
 		return perrors.WithMessagef(err, "time.ParseDuration(HeartbeatPeroid{%#v})", c.HeartbeatPeriod)
 	}
 
-	if c.heartbeatPeriod >= time.Duration(config.MaxWheelTimeSpan) {
+	if c.heartbeatPeriod >= time.Duration(constant.MaxWheelTimeSpan) {
 		return perrors.WithMessagef(err, "heartbeat-period %s should be less than %s",
-			c.HeartbeatPeriod, time.Duration(config.MaxWheelTimeSpan))
+			c.HeartbeatPeriod, time.Duration(constant.MaxWheelTimeSpan))
 	}
 
 	if len(c.HeartbeatTimeout) == 0 {
-		c.heartbeatTimeout = 60 * time.Second
+		c.heartbeatTimeout = constant.DefaultHeartbeatTimeout
 	} else if c.heartbeatTimeout, err = time.ParseDuration(c.HeartbeatTimeout); err != nil {
 		return perrors.WithMessagef(err, "time.ParseDuration(HeartbeatTimeout{%#v})", c.HeartbeatTimeout)
 	}
@@ -235,18 +235,18 @@ func (c *ServerConfig) CheckValidity() error {
 	var err error
 
 	if len(c.HeartbeatPeriod) == 0 {
-		c.heartbeatPeriod = 60 * time.Second
+		c.heartbeatPeriod = constant.DefaultHeartbeatTimeout
 	} else if c.heartbeatPeriod, err = time.ParseDuration(c.HeartbeatPeriod); err != nil {
 		return perrors.WithMessagef(err, "time.ParseDuration(HeartbeatPeroid{%#v})", c.HeartbeatPeriod)
 	}
 
-	if c.heartbeatPeriod >= time.Duration(config.MaxWheelTimeSpan) {
+	if c.heartbeatPeriod >= time.Duration(constant.MaxWheelTimeSpan) {
 		return perrors.WithMessagef(err, "heartbeat-period %s should be less than %s",
-			c.HeartbeatPeriod, time.Duration(config.MaxWheelTimeSpan))
+			c.HeartbeatPeriod, time.Duration(constant.MaxWheelTimeSpan))
 	}
 
 	if len(c.HeartbeatTimeout) == 0 {
-		c.heartbeatTimeout = 60 * time.Second
+		c.heartbeatTimeout = constant.DefaultHeartbeatTimeout
 	} else if c.heartbeatTimeout, err = time.ParseDuration(c.HeartbeatTimeout); err != nil {
 		return perrors.WithMessagef(err, "time.ParseDuration(HeartbeatTimeout{%#v})", c.HeartbeatTimeout)
 	}
@@ -255,9 +255,9 @@ func (c *ServerConfig) CheckValidity() error {
 		return perrors.WithMessagef(err, "time.ParseDuration(SessionTimeout{%#v})", c.SessionTimeout)
 	}
 
-	if c.sessionTimeout >= time.Duration(config.MaxWheelTimeSpan) {
+	if c.sessionTimeout >= time.Duration(constant.MaxWheelTimeSpan) {
 		return perrors.WithMessagef(err, "session-timeout %s should be less than %s",
-			c.SessionTimeout, time.Duration(config.MaxWheelTimeSpan))
+			c.SessionTimeout, time.Duration(constant.MaxWheelTimeSpan))
 	}
 
 	return perrors.WithStack(c.GettySessionParam.CheckValidity())

--- a/remoting/getty/getty_client_test.go
+++ b/remoting/getty/getty_client_test.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"dubbo.apache.org/dubbo-go/v3/global"
 )
 
 import (
@@ -36,7 +38,7 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
-	. "dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
@@ -58,7 +60,7 @@ func testRequestOneWay(t *testing.T, client *Client) {
 	request := remoting.NewRequest("2.0.2")
 	invocation := createInvocation("GetUser", nil, nil, []any{"1", "username"},
 		[]reflect.Value{reflect.ValueOf("1"), reflect.ValueOf("username")})
-	attachment := map[string]string{InterfaceKey: "com.ikurento.user.UserProvider"}
+	attachment := map[string]string{constant.InterfaceKey: "com.ikurento.user.UserProvider"}
 	setAttachment(invocation, attachment)
 	request.Data = invocation
 	request.Event = false
@@ -97,7 +99,7 @@ func testClient_AsyncCall(t *testing.T, client *Client) {
 	request := remoting.NewRequest("2.0.2")
 	invocation := createInvocation("GetUser0", nil, nil, []any{"4", nil, "username"},
 		[]reflect.Value{reflect.ValueOf("4"), reflect.ValueOf(nil), reflect.ValueOf("username")})
-	attachment := map[string]string{InterfaceKey: "com.ikurento.user.UserProvider"}
+	attachment := map[string]string{constant.InterfaceKey: "com.ikurento.user.UserProvider"}
 	setAttachment(invocation, attachment)
 	request.Data = invocation
 	request.Event = false
@@ -271,7 +273,8 @@ func (u User) JavaClassName() string {
 	return "com.ikurento.user.User"
 }
 
-func TestInitClient(t *testing.T) {
+// TODO: Temporary compatibility with old APIs, can be removed later
+func TestInitClientOldApi(t *testing.T) {
 	originRootConf := config.GetRootConfig()
 	rootConf := config.RootConfig{
 		Protocols: map[string]*config.ProtocolConfig{
@@ -285,7 +288,21 @@ func TestInitClient(t *testing.T) {
 	config.SetRootConfig(rootConf)
 	url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
 	assert.Nil(t, err)
-	initServer(url)
+	initClient(url)
 	config.SetRootConfig(*originRootConf)
 	assert.NotNil(t, srvConf)
+}
+
+func TestInitClient(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+	assert.Nil(t, err)
+	url.SetAttribute(constant.ProtocolConfigKey, map[string]*global.ProtocolConfig{
+		"dubbo": {
+			Name: "dubbo",
+			Ip:   "127.0.0.1",
+			Port: "20003",
+		},
+	})
+	url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
+	initClient(url)
 }

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -35,6 +35,7 @@ import (
 )
 
 import (
+	"dubbo.apache.org/dubbo-go/v3"
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
@@ -56,20 +57,52 @@ func initServer(url *common.URL) {
 
 	// load server config from rootConfig.Protocols
 	// default use dubbo
-	if config.GetApplicationConfig() == nil {
-		return
-	}
-	if config.GetRootConfig().Protocols == nil {
+	// TODO: Temporary compatibility with old APIs, can be removed later
+	if url.GetParam(constant.ApplicationKey, "") == "" && config.GetApplicationConfig() == nil {
 		return
 	}
 
-	protocolConf := config.GetRootConfig().Protocols[url.Protocol]
+	// TODO: Temporary compatibility with old APIs, can be removed later
+	if url.GetParam(constant.ProtocolKey, "") == "" && config.GetRootConfig().Protocols == nil {
+		return
+	}
+
+	//TODO: Temporary compatibility with old APIs, can be removed later
+	protocolConfMap := dubbo.CompatGlobalProtocolConfigMap(config.GetRootConfig().Protocols)
+	if protocolConfMap == nil {
+		if protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey); ok {
+			protocolConfig, ok := protocolConfRaw.(map[string]*global.ProtocolConfig)
+			if !ok {
+				logger.Warnf("protocolConfig assert failed")
+				return
+			}
+			if protocolConfig == nil {
+				logger.Warnf("protocolConfig is nil")
+				return
+			}
+			protocolConfMap = protocolConfig
+		}
+	}
+
+	protocolConf := protocolConfMap[url.Protocol]
 	if protocolConf == nil {
 		logger.Debug("use default getty server config")
 		return
 	} else {
 		//server tls config
-		tlsConfig := config.GetRootConfig().TLSConfig
+		tlsConfig := dubbo.CompatGlobalTLSConfig(config.GetRootConfig().TLSConfig)
+
+		if tlsConfig == nil {
+			if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
+				tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
+				if !ok {
+					logger.Errorf("Getty client initialized the TLSConfig configuration failed")
+					return
+				}
+				tlsConfig = tlsConf
+			}
+		}
+
 		if tlsConfig != nil {
 			srvConf.SSLEnabled = true
 			srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{

--- a/remoting/getty/getty_server_test.go
+++ b/remoting/getty/getty_server_test.go
@@ -19,6 +19,9 @@ package getty
 
 import (
 	"testing"
+
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/global"
 )
 
 import (
@@ -30,7 +33,8 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/config"
 )
 
-func TestInitServer(t *testing.T) {
+// TODO: Temporary compatibility with old APIs, can be removed later
+func TestInitServerOldApi(t *testing.T) {
 	originRootConf := config.GetRootConfig()
 	rootConf := config.RootConfig{
 		Protocols: map[string]*config.ProtocolConfig{
@@ -47,4 +51,18 @@ func TestInitServer(t *testing.T) {
 	initServer(url)
 	config.SetRootConfig(*originRootConf)
 	assert.NotNil(t, srvConf)
+}
+
+func TestInitServer(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+	assert.Nil(t, err)
+	url.SetAttribute(constant.ProtocolConfigKey, map[string]*global.ProtocolConfig{
+		"dubbo": {
+			Name: "dubbo",
+			Ip:   "127.0.0.1",
+			Port: "20003",
+		},
+	})
+	url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
+	initServer(url)
 }


### PR DESCRIPTION
## Summary by Sourcery

Allow getty client and server to use new API for protocol and TLS configurations via URL attributes while maintaining backward compatibility, centralize default time constants, and update tests accordingly.

New Features:
- Support loading protocol and TLS configurations from URL attributes in initClient and initServer for the new API
- Maintain backward compatibility by falling back to legacy global protocol and TLS configs when URL attributes are absent

Enhancements:
- Add CompatGlobalTLSConfig to convert legacy config.TLSConfig into global.TLSConfig
- Centralize MaxWheelTimeSpan and DefaultHeartbeatTimeout in common constants and refactor getty config validity checks to use them

Tests:
- Rename legacy TestInitClient and TestInitServer to TestInitClientOldApi and TestInitServerOldApi
- Add new tests for initClient and initServer using URL-based configuration
- Update client tests to use constant.InterfaceKey instead of raw InterfaceKey string

Chores:
- Remove duplicate MaxWheelTimeSpan constant from consumer_config.go
- Clean up imports in getty config and client/server files